### PR TITLE
Fix network connection check with netinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "redux-thunk": "^2.3.0"
   },
   "dependencies": {
-    "@react-native-community/netinfo": "^4.1.2",
+    "@react-native-community/netinfo": "^5.3.1",
     "lodash": "^4.17.11",
     "react-redux": "^6.0.0 || ^7.0.0",
     "redux": "4.x",

--- a/src/components/NetworkConnectivity.js
+++ b/src/components/NetworkConnectivity.js
@@ -81,7 +81,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
     const { pingInterval } = this.props;
     const handler = this.getConnectionChangeHandler();
 
-    NetInfo.isConnected.addEventListener('connectionChange', handler);
+    NetInfo.addEventListener('connectionChange', handler);
     // On Android the listener does not fire on startup
     if (Platform.OS === 'android') {
       const netConnected = await NetInfo.isConnected.fetch();
@@ -116,7 +116,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
       : this.handleConnectivityChange;
   }
 
-  handleNetInfoChange = (isConnected: boolean) => {
+  handleNetInfoChange = ({ isConnected }) => {
     if (!isConnected) {
       this.handleConnectivityChange(isConnected);
     } else {
@@ -151,7 +151,7 @@ class NetworkConnectivity extends React.PureComponent<Props, State> {
     this.checkInternet();
   };
 
-  handleConnectivityChange = (isConnected: boolean) => {
+  handleConnectivityChange = ({ isConnected }) => {
     this.setState({
       isConnected,
     });

--- a/src/redux/sagas.js
+++ b/src/redux/sagas.js
@@ -25,7 +25,7 @@ type Arguments = {
 };
 
 export function netInfoEventChannelFn(emit: (param: boolean) => mixed) {
-  NetInfo.isConnected.addEventListener('connectionChange', emit);
+  NetInfo.addEventListener('connectionChange', emit);
   return () => {
     NetInfo.isConnected.removeEventListener('connectionChange', emit);
   };

--- a/src/utils/checkInternetConnection.js
+++ b/src/utils/checkInternetConnection.js
@@ -16,7 +16,7 @@ export default async function checkInternetConnection(
   timeout: number = DEFAULT_TIMEOUT,
   shouldPing: boolean = true,
 ): Promise<boolean> {
-  return NetInfo.isConnected.fetch().then(async (isConnected: boolean) => {
+  return NetInfo.fetch().then(async ({ isConnected }) => {
     if (shouldPing) {
       const hasInternetAccess = await checkInternetAccess({ timeout, url });
       return hasInternetAccess;


### PR DESCRIPTION
According to this : https://github.com/react-native-community/react-native-netinfo/pull/256
NetInfo module functions has changed and that was not working on iOS anymore. see #240

## Motivation

What existing problem does the pull request solve? 
Fix issue #240

## Test plan

Test it on newer version of react-native-netinfo